### PR TITLE
Delete .gemspec

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -1,1 +1,0 @@
-rdf-turtle.gemspec


### PR DESCRIPTION
Delete .gemspec so that rdf meta-gem works on Windows
