### PR TITLE
Remove bigdecimal dependency declaration

### DIFF
--- a/rdf-turtle.gemspec
+++ b/rdf-turtle.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 3.0'
   gem.requirements          = []
   gem.add_runtime_dependency     'base64',          '~> 0.2'
-  gem.add_runtime_dependency     'bigdecimal',      '~> 3.1', '>= 3.1.9'
   gem.add_runtime_dependency     'ebnf',            '~> 2.6'
   gem.add_runtime_dependency     'rdf',             '~> 3.3', '>= 3.3.4'
   gem.add_runtime_dependency     'readline',        '~> 0.0'


### PR DESCRIPTION
The BigDecimal class is not used in this code base. And since we have a circular dependency from rdf to rdf-turtle and back, we are otherwise unable to update the bigdecimal gem in the main rdf repository.

So I'm violating the contrbuting guidelines here:

> Don't touch the .gemspec or VERSION files. If you need to change them, do so on your private branch only.

But I don't know which flow Gregg used to update those dependencies? Please let me know if there's a better approach.